### PR TITLE
feat(types): improve types

### DIFF
--- a/lua/freeze/init.lua
+++ b/lua/freeze/init.lua
@@ -45,6 +45,7 @@ M.allowed_opts = {
   },
 }
 
+-- Parse the options provided by the user and ensure they are valid
 M.parse_options = function(opts)
   local options
 
@@ -84,20 +85,20 @@ end
 -- Populate the command line arguments
 local function populate_cmd(cmd, args, tbl, prefix)
   for k, v in pairs(tbl) do
-    -- handle margin and padding separately as tables
+    -- Handle margin and padding separately as tables
     if k == "margin" or k == "padding" then
       if type(v) == "table" then
         table.insert(cmd, "--" .. prefix .. k)
         table.insert(cmd, table.concat(v, ","))
       end
-    -- table options ('border', 'font', 'shadow')
+    -- Table options ('border', 'font', 'shadow')
     elseif type(v) == "table" and not is_array(v) then
       populate_cmd(cmd, args, v, prefix .. k .. ".")
-    -- handle anything that is not the command or language option
+    -- Handle anything that is not the command or language option
     elseif k ~= "command" and k ~= "language" then
       table.insert(cmd, "--" .. prefix .. string.gsub(k, "_", "-"))
 
-      -- if the value is a function, call it with the args, otherwise just use the value
+      -- If the value is a function, call it with the args, otherwise just use the value
       local value = nil
       if type(v) == "function" then
         value = v(args)
@@ -152,15 +153,15 @@ end
 M.start = function(args, options)
   local lines = nil
 
-  -- start building the base of the command from the options
+  -- Start building the base of the command from the options
   local base_cmdline = M.get_arguments(args, options)
-  -- parse buffer into lines, based on arguments from neovim, reshapes cmdline
+  -- Parse buffer into lines, based on arguments from neovim, reshapes cmdline
   lines, base_cmdline = M.format_lines(base_cmdline, args)
 
   local cmd = vim.tbl_extend("error", base_cmdline, {})
 
-  -- if the user gave us a language lets use it
-  -- else try to get the language from neovim's buffer filetype
+  -- If the user gave us a language lets use it
+  -- Else try to get the language from neovim's buffer filetype
   table.insert(cmd, "--language")
   if options.language then
     table.insert(cmd, options.language)
@@ -168,7 +169,7 @@ M.start = function(args, options)
     table.insert(cmd, vim.bo.filetype)
   end
 
-  -- run the command and get the output
+  -- Run the command and get the output
   local ret = vim.fn.system(cmd, lines)
   if string.find(ret, "WROTE") then
     return vim.notify("File saved to" .. string.sub(ret, 8), vim.log.levels.INFO, { title = "freeze.nvim" })

--- a/lua/freeze/init.lua
+++ b/lua/freeze/init.lua
@@ -1,3 +1,4 @@
+---@class Freeze
 local M = {}
 
 ---@param ... table
@@ -44,7 +45,6 @@ M.allowed_opts = {
   },
 }
 
----@param opts table
 M.parse_options = function(opts)
   local options
 
@@ -81,10 +81,7 @@ M.parse_options = function(opts)
   return options
 end
 
----@param cmd table
----@param args table
----@param tbl table
----@param prefix string
+-- Populate the command line arguments
 local function populate_cmd(cmd, args, tbl, prefix)
   for k, v in pairs(tbl) do
     -- handle margin and padding separately as tables
@@ -117,9 +114,6 @@ local function populate_cmd(cmd, args, tbl, prefix)
 end
 
 -- Generate the command line arguments
----@param args table
----@param options table
----@return table
 M.get_arguments = function(args, options)
   local cmd = {}
 
@@ -129,10 +123,7 @@ M.get_arguments = function(args, options)
   return cmd
 end
 
--- get lines and format them for the command
----@param cmdline table
----@param args table
----@return table lines, table cmdline
+-- Get lines and format them for the command
 M.format_lines = function(cmdline, args)
   local begin_line = args.line1 - 1
   local finish_line = args.line2
@@ -157,8 +148,7 @@ M.format_lines = function(cmdline, args)
   return lines, cmdline
 end
 
----@param args table
----@param options table
+-- Start freeze.nvim with the given arguments and options
 M.start = function(args, options)
   local lines = nil
 
@@ -187,7 +177,7 @@ M.start = function(args, options)
   end
 end
 
--- define commands for neovim
+-- Define commands for neovim
 M.setup = function(opts)
   local options = M.parse_options(opts)
 

--- a/lua/freeze/types.lua
+++ b/lua/freeze/types.lua
@@ -1,0 +1,28 @@
+---@meta
+
+---@alias OptionsType "string"|"table"|"function"|"boolean"|"number"|"nil"
+
+---@class FreezeOptions
+---@field command OptionsType
+---@field config OptionsType
+---@field output table<OptionsType>
+---@field window OptionsType
+---@field padding table<OptionsType>
+---@field margin table<OptionsType>
+---@field background OptionsType
+---@field theme OptionsType
+---@field show_line_numbers OptionsType
+---@field line_height OptionsType
+---@field language OptionsType
+---@field font table<string, OptionsType>
+---@field shadow table<string, OptionsType>
+---@field border table<string, OptionsType>
+
+---@class Freeze
+---@field required_options table<string, string>
+---@field allowed_opts FreezeOptions
+---@field parse_options fun(opts: FreezeOptions): FreezeOptions
+---@field get_arguments fun(args: table<string, number>, options: FreezeOptions): table<string>
+---@field format_lines fun(cmdline: table<string>, args: table<string, number>): table<string>, table<string>
+---@field start fun(args: table<string, number>, options: FreezeOptions)
+---@field setup fun(opts: FreezeOptions)


### PR DESCRIPTION
@isabelroses I've separated the types in its own file but it can be in the `init.lua`, I did it to have the types definitions separated as it's the best practice.

In this PR apart from the aforementioned change, I created more specific types and made starting comments in uppercase in all instances, since there was a combo of lower and upper when I was adding some myself