### PR TITLE
feat(#13): add `:Freeze ...` complete behaviour

### DIFF
--- a/lua/freeze/init.lua
+++ b/lua/freeze/init.lua
@@ -160,10 +160,21 @@ M.start = function(args, options)
 
   local cmd = vim.tbl_extend("error", base_cmdline, {})
 
+  args = args.fargs or {}
+  local args_list = {}
+  -- Parse the arguments into a table
+  for _, v in ipairs(args) do
+    local key = vim.split(v, "=")[1]
+    local value = vim.split(v, "=")[2]
+    args_list[key] = value
+  end
+
   -- If the user gave us a language lets use it
   -- Else try to get the language from neovim's buffer filetype
   table.insert(cmd, "--language")
-  if options.language then
+  if args_list.language then
+    table.insert(cmd, args_list.language)
+  elseif options.language then
     table.insert(cmd, options.language)
   else
     table.insert(cmd, vim.bo.filetype)
@@ -188,6 +199,21 @@ M.setup = function(opts)
     desc = "convert range to code image representation",
     force = false,
     range = true,
+    nargs = "*",
+    complete = function(_, line)
+      local opts_list = vim.tbl_keys(M.allowed_opts)
+      local l = vim.split(line, "%s+")
+      -- Remove `command` from the list of options
+      for i, v in ipairs(opts_list) do
+        if v == "command" then
+          table.remove(opts_list, i)
+        end
+      end
+      table.sort(opts_list)
+      return vim.tbl_filter(function(opt)
+        return vim.startswith(opt, l[#l])
+      end, opts_list)
+    end,
   })
 end
 


### PR DESCRIPTION
As mention, this will allow to have completion to tweak **freeze** options/flags from the vim cmdline:

**Usage**:

- `:Freeze ` your completion trigger (usually `<Tab>`) and select one.
  - Once selected, append `=` and the desired value, eg. `:Freeze language=txt` will translate to `--language=txt`.

---

**Demo with complete options** (only language implemented):

https://github.com/user-attachments/assets/b896a03b-9e47-4eaf-9c9c-f285cc843052

> [!note]
> I showcase also the problem mentioned that `vim.bo.ft` won't always work or cases where freeze has no filetype support.

---

**TODO**:
- [ ] Parse options like `boolean` and `table` so it can be validated.
- [ ] Validate options once the arguments are passed.
- [ ] Implement all the options.