### PR TITLE
fix: allow functions that return strings for output

### DIFF
--- a/lua/freeze/init.lua
+++ b/lua/freeze/init.lua
@@ -89,7 +89,12 @@ end
 local function open_by_os(args)
   local is_win = vim.loop.os_uname().sysname:match("Windows")
   local is_linux = vim.loop.os_uname().sysname:match("Linux")
-  local output = vim.fn.expand(args.output)
+  local output
+  if type(args.output) == "function" then
+    output = vim.fn.expand(args.output())
+  else
+    output = vim.fn.expand(args.output)
+  end
   local cmd = {}
   if is_win then
     table.insert(cmd, "explorer")


### PR DESCRIPTION
When copying the suggested config in the readme, I found a bug with the `open_by_os` function where it was passing the output to `vim.fn.expand` which expects a string. The suggested config in the readme is actually a function that returns  a string, resulting in the following error:

<img width="1512" alt="image" src="https://github.com/user-attachments/assets/3911f0bb-1b8a-4ee8-ba73-311f82b1a536">

This fix allows for output to be either a string or a function that returns a string, in order to support the suggested config in the readme.